### PR TITLE
Make parsed headers unique, with order encountered.

### DIFF
--- a/convert_eprime/convert.py
+++ b/convert_eprime/convert.py
@@ -25,6 +25,7 @@ import os
 import sys
 import json
 import inspect
+from collections import OrderedDict
 
 import pandas as pd
 import numpy as np
@@ -212,7 +213,7 @@ def _text_to_df(text_file):
             split_header_idx = col_val.index(':')
             headers.append(col_val[:split_header_idx])
 
-    headers = list(set(headers))
+    headers = list(OrderedDict.fromkeys(headers))
 
     # Preallocate list of lists composed of NULLs.
     data_matrix = np.empty((n_rows, len(headers)), dtype=object)


### PR DESCRIPTION
This PR adds support for unique headers with order they are encountered preserved by using `OrderedDict`, per this [SO post](https://stackoverflow.com/a/17016257). It makes the converted CSVs a bit nicer to look directly at because the column ordering per section is the same as the ordering in the `.txt` file. `OrderedDict` seems to require Python 2.7, and I haven't tested this code on Python 3.x.