### PR TITLE
Contingency for crash-dump metadata

### DIFF
--- a/convert_eprime/convert.py
+++ b/convert_eprime/convert.py
@@ -206,8 +206,8 @@ def _text_to_df(text_file):
         # In cases of an experiment crash, the final LogFrame is never written, and the experiment metadata
         # (Subject, VersionNumber, etc.) isn't collected by the indices above. We can manually include the
         # metadata-containing Header Frame to collect these data from a partial-run crash dump.
-        start_index += [i for i,row in enumerate(filtered_data) if row == '*** Header Start ***']
-        end_index += [i for i,row in enumerate(filtered_data) if row == '*** Header End ***']
+        start_index = [i for i,row in enumerate(filtered_data) if row == '*** Header Start ***'] + start_index
+        end_index = [i for i,row in enumerate(filtered_data) if row == '*** Header End ***'] + end_index
     n_rows = min(len(start_index), len(end_index))
 
     # Find column headers and remove duplicates.

--- a/convert_eprime/convert.py
+++ b/convert_eprime/convert.py
@@ -202,7 +202,7 @@ def _text_to_df(text_file):
     end_index = [i for i, row in enumerate(filtered_data) if row == '*** LogFrame End ***']
     if len(start_index) != len(end_index) or start_index[0] >= end_index[0]:
         print('Warning: LogFrame Starts and Ends do not match up.',
-              'Including eader metadata just in case.')
+              'Including header metadata just in case.')
         # In cases of an experiment crash, the final LogFrame is never written, and the experiment metadata
         # (Subject, VersionNumber, etc.) isn't collected by the indices above. We can manually include the
         # metadata-containing Header Frame to collect these data from a partial-run crash dump.

--- a/convert_eprime/convert.py
+++ b/convert_eprime/convert.py
@@ -201,10 +201,11 @@ def _text_to_df(text_file):
     start_index = [i for i, row in enumerate(filtered_data) if row == '*** LogFrame Start ***']
     end_index = [i for i, row in enumerate(filtered_data) if row == '*** LogFrame End ***']
     if len(start_index) != len(end_index) or start_index[0] >= end_index[0]:
-    # In cases of an experiment crash, the final LogFrame is never written, and the experiment metadata
-    # (Subject, VersionNumber, etc.) isn't collected by the indices above. We can manually include the
-    # metadata-containing Header Frame to collect these data from a partial-run crash dump.
-        print('Warning: LogFrame Starts and Ends do not match up.')
+        print('Warning: LogFrame Starts and Ends do not match up.',
+              'Including eader metadata just in case.')
+        # In cases of an experiment crash, the final LogFrame is never written, and the experiment metadata
+        # (Subject, VersionNumber, etc.) isn't collected by the indices above. We can manually include the
+        # metadata-containing Header Frame to collect these data from a partial-run crash dump.
         start_index += [i for i,row in enumerate(filtered_data if row == '*** Header Start ***']
         end_index += [i for i,row in enumerate(filtered_data if row == '*** Header_End ***']
     n_rows = min(len(start_index), len(end_index))

--- a/convert_eprime/convert.py
+++ b/convert_eprime/convert.py
@@ -201,7 +201,12 @@ def _text_to_df(text_file):
     start_index = [i for i, row in enumerate(filtered_data) if row == '*** LogFrame Start ***']
     end_index = [i for i, row in enumerate(filtered_data) if row == '*** LogFrame End ***']
     if len(start_index) != len(end_index) or start_index[0] >= end_index[0]:
+    # In cases of an experiment crash, the final LogFrame is never written, and the experiment metadata
+    # (Subject, VersionNumber, etc.) isn't collected by the indices above. We can manually include the
+    # metadata-containing Header Frame to collect these data from a partial-run crash dump.
         print('Warning: LogFrame Starts and Ends do not match up.')
+        start_index += [i for i,row in enumerate(filtered_data if row == '*** Header Start ***']
+        end_index += [i for i,row in enumerate(filtered_data if row == '*** Header_End ***']
     n_rows = min(len(start_index), len(end_index))
 
     # Find column headers and remove duplicates.

--- a/convert_eprime/convert.py
+++ b/convert_eprime/convert.py
@@ -206,8 +206,8 @@ def _text_to_df(text_file):
         # In cases of an experiment crash, the final LogFrame is never written, and the experiment metadata
         # (Subject, VersionNumber, etc.) isn't collected by the indices above. We can manually include the
         # metadata-containing Header Frame to collect these data from a partial-run crash dump.
-        start_index += [i for i,row in enumerate(filtered_data if row == '*** Header Start ***']
-        end_index += [i for i,row in enumerate(filtered_data if row == '*** Header_End ***']
+        start_index += [i for i,row in enumerate(filtered_data) if row == '*** Header Start ***']
+        end_index += [i for i,row in enumerate(filtered_data) if row == '*** Header End ***']
     n_rows = min(len(start_index), len(end_index))
 
     # Find column headers and remove duplicates.


### PR DESCRIPTION
When E-prime crashes or, for whatever reason, an experiment doesn't finish, the .txt log terminates at the moment of termination. The final LogFrame is never written, which is where `_text_to_df()` imports all of the experiment metadata from.

That metadata does exist in the Header Frame, though, so I just added a small contingency when `_text_to_df()` detects a terminated LogFrame, which adds the Header Frame Start and Header Frame End rows to `start_index` and `end_index`, respectively. This way, the DataFrame is guaranteed to contain that critical metadata even when the file is incomplete.

**This change should have no effect on the conversion of normal .txt log files.**